### PR TITLE
exampleSite themesDir added; Next and Prev will be deprecated, use NextPage a…

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,6 +2,7 @@ baseurl = "http://example.org/"
 languageCode = "en-us"
 title = "Hugo Cards"
 theme = "hugo-cards"
+themesDir = "../.."
 paginate = 6
 
 [params]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -22,10 +22,10 @@
     
     <div class="row">
             <ul class="pager">
-             {{ with .Next }}
+             {{ with .NextPage }}
                     <li><a class="next" href="{{ .URL }}">&laquo; {{ .Title }}</a></li>
               {{ end }}
-              {{ with .Prev }}
+              {{ with .PrevPage }}
                 <li><a class="previous" href="{{ .URL }}">{{ .Title }} &raquo;</a></li>
               {{ end }}
             </ul>


### PR DESCRIPTION
…nd PrevPage respectively

the changes on single.html from the layouts dir of `Prev` and `Next` to `PrevPage` and `NextPage` come from the most recent hugo