### PR TITLE
New option to allow overwriting the CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ The Google Analytics tracking ID
 
 #### disqus
 The disqus_thread ID
+
+### Customization
+
+#### custom_css
+Relative links with custom.css files. This will let yout overwrite the theme's CSS.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -23,6 +23,8 @@ paginate = 6
   analytics = ""
   disqus = ""
 
+  #custom_css = ["css/custom.css"]
+
   [params.copyright]
      name = "bool"
      link = "https://bool.netlify.com"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,4 +9,7 @@
 {{ $main := resources.Get "sass/main.scss" | resources.ToCSS (dict "outputStyle" "compressed")}}
 <link rel="stylesheet" href="{{ $main.RelPermalink }}">
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="/{{ . }}">
+{{- end }}
 </head>


### PR DESCRIPTION
Great theme! but I't would be even better if it would be possible to customize some parts.

Taken from the [forum](https://discourse.gohugo.io/t/how-to-override-css-classes-with-hugo/3033/2), this allow to drop a css file and overwrite the main.css.