### PR TITLE
Allow images both in resources or in static folder

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,13 @@
                 <div class="panel panel-default">
                   
                   {{ if .Params.img }}
-                  <img width="100%" src="{{ .Site.BaseURL }}images/{{ .Params.img }}" alt="{{ .Title }}">
+                  {{ with .Resources.Match .Params.img }}
+                    {{ range . }}
+                      <img width="100%" src="{{ .RelPermalink }}" alt="{{ .Title }}">
+                    {{ end }}
+                  {{ else }}
+                    <img src="{{ .Site.BaseURL }}images/{{ .Params.img }}" alt="{{ .Title }}">
+                  {{ end }}
                   {{ else }}
                   <img width="100%" src="{{ .Site.BaseURL }}images/{{ .Site.Params.defaultImage }}" alt="{{ .Site.Title }}">
                   {{ end }}

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -30,7 +30,7 @@
       "@type": "Person",
       "name": "{{ .Site.Params.author }}"
     },
-  "description": "{{ .Site.Params.description }}",
+  "description": "{{ .Site.Params.description }}"
 }
 </script>
 {{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,7 +1,13 @@
 <div class="col-md-4 mt20">
         <div class="post-img">
            {{ if .Params.img }}
-            <img width="600" src="{{ .Site.BaseURL}}images/{{ .Params.img }}" alt="{{ .Params.title }}">
+            {{ with .Resources.Match .Params.img }}
+              {{ range . }}
+                <img width="100%" src="{{ .RelPermalink }}" alt="{{ .Title }}">
+              {{ end }}
+        {{ else }}
+        <img width="100%" src="{{ .Site.BaseURL }}images/{{ .Params.img }}" alt="{{ .Title }}">
+            {{ end }}
             {{ else }}
             <img width="600" src="{{ .Site.BaseURL }}images/{{ .Site.Params.defaultImage }}" alt="webjeda">
             {{ end }}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -12,7 +12,13 @@
                 <div class="panel panel-default">
                   
                   {{ if .Params.img }}
+                  {{ with .Resources.Match .Params.img }}
+                    {{ range . }}
+                      <img width="100%" src="{{ .RelPermalink }}" alt="{{ .Title }}">
+                    {{ end }}
+                  {{ else }}
                   <img width="100%" src="{{ .Site.BaseURL }}images/{{ .Params.img }}" alt="{{ .Title }}">
+                  {{ end }}
                   {{ else }}
                   <img width="100%" src="{{ .Site.BaseURL }}images/{{ .Site.Params.defaultImage }}" alt="{{ .Site.Title }}">
                   {{ end }}


### PR DESCRIPTION
Hi, I've made several changes to the theme in https://gitlab.com/Marzal/hugo-cards-podcast to use in a few podcast websites, some of the changes I think that can be upstreamed to allow more customization without touching the theme folder.

If you want, I can send you a few more changes/MR.

This one for example allows to use the old way to reference pictures as a sencond option.
If `.Resources.Match .Params.img` doesn't find anythin, it would look in the static folder again. I need this for backward compatibility with a repo with lots of articles and also it's easier to reuse a picture in multiples places without learning hugo resouces.