### PR TITLE
Delete a slash after `.Site.BaseURL`.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,7 @@
     {{ partial "footer.html" . }}    
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
-  <script src="{{ .Site.BaseURL }}/js/bootstrap.min.js"></script>
+  <script src="{{ .Site.BaseURL }}js/bootstrap.min.js"></script>
   {{ with .Site.Params.analytics }} 
     {{ partial "analytics.html" . }}
   {{ end }}


### PR DESCRIPTION
The web server based on Azure Storage Account can't handle a double slashed URL.

e.g. https://example.com//js/bootstrap.min.js is not acceptable.
It should be https://example.com/js/bootstrap.min.js